### PR TITLE
feat: Add fallback option for browsers that don't support date input

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -15,6 +15,7 @@ import { apiService } from './js/apiService';
 import { dateController } from './js/dateController';
 import { viewUpdater } from './js/viewUpdater';
 import { cityController } from './js/cityController';
+import { dateInputFactory } from './js/dateInputFactory';
 
 // *** STYLESHEETS ***
 import './styles/style.scss';
@@ -24,9 +25,13 @@ import './styles/form.scss';
 // Configure dependencies for the viewUpdater
 viewUpdater.applicationState = applicationState;
 
+// Configure dependencies for the dateInputFactory
+dateInputFactory.viewUpdater = viewUpdater;
+
 // Configure dependencies for the date controller
 dateController.applicationState = applicationState;
 dateController.viewUpdater = viewUpdater;
+dateController.dateInputFactory = dateInputFactory;
 
 // Configure dependencies for the dropdown list
 cityController.apiService = apiService;

--- a/src/client/js/dateController.js
+++ b/src/client/js/dateController.js
@@ -1,8 +1,9 @@
 const dateController = (function () {
     let _applicationState;
     let _viewUpdater;
-    const startDateInput = document.getElementById('startDate');
-    const endDateInput = document.getElementById('endDate');
+    let _dateInputFactory;
+    let startDateInput;
+    let endDateInput;
     const millisecondsInOneDay = 24 * 3600 * 1000;
     const today = getTodaysDate();
     const tomorrow = new Date(today.getTime() + millisecondsInOneDay);
@@ -22,17 +23,22 @@ const dateController = (function () {
     }
 
     function initializeState() {
+        startDateInput = _dateInputFactory.createDateInput(
+            'startDate',
+            'Start Date'
+        );
         startDateInput.value = getDateAsString(today);
         _applicationState.startDate = startDateInput.value;
+        endDateInput = _dateInputFactory.createDateInput('endDate', 'End Date');
         endDateInput.value = getDateAsString(tomorrow);
         _applicationState.endDate = endDateInput.value;
-        _applicationState.duration = 1;
+        _applicationState.duration = 2;
         _applicationState.daysToTrip = 0;
     }
 
     function getValidatedDates() {
-        let startDate = new Date(startDateInput.value.split('-'));
-        let endDate = new Date(endDateInput.value.split('-'));
+        let startDate = new Date(startDateInput.value);
+        let endDate = new Date(endDateInput.value);
         const result = { startDate, endDate };
 
         if (startDate.getTime() < today.getTime()) {
@@ -53,10 +59,8 @@ const dateController = (function () {
     function updateState(newState) {
         if (!newState.error) {
             const daysToTrip = getDifferenceInDays(today, newState.startDate);
-            const duration = getDifferenceInDays(
-                newState.startDate,
-                newState.endDate
-            );
+            const duration =
+                getDifferenceInDays(newState.startDate, newState.endDate) + 1;
             _applicationState.startDate = getDateAsString(newState.startDate);
             _applicationState.endDate = getDateAsString(newState.startDate);
             _applicationState.daysToTrip = daysToTrip;
@@ -107,6 +111,9 @@ const dateController = (function () {
         },
         set viewUpdater(viewUpdater) {
             _viewUpdater = viewUpdater;
+        },
+        set dateInputFactory(dateInputFactory) {
+            _dateInputFactory = dateInputFactory;
         },
         start: () => {
             setDateFields();

--- a/src/client/js/dateInputFactory.js
+++ b/src/client/js/dateInputFactory.js
@@ -1,0 +1,101 @@
+const dateInputFactory = (function () {
+    let _viewUpdater;
+    function createDateInput(id, labelText) {
+        // test whether a new date input falls back to a text input or not
+        const test = document.createElement('INPUT');
+
+        try {
+            test.type = 'date';
+        } catch (e) {
+            console.log(e.description);
+        }
+
+        if (test.type === 'text') {
+            return createFallbackDateInput(id, labelText);
+        } else {
+            return createNativeDateInput(id, labelText);
+        }
+    }
+
+    function createNativeDateInput(id, labelText) {
+        _viewUpdater.renderNativeDateInput(id, labelText);
+        const input = document.getElementById(id);
+
+        function addEventListener(event, callback) {
+            input.addEventListener(event, callback);
+        }
+        return {
+            get value() {
+                return input.value;
+            },
+            set value(value) {
+                input.value = value;
+            },
+            addEventListener,
+        };
+    }
+
+    // This fallback date input is based on
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#Handling_browser_support
+    function createFallbackDateInput(id, labelText) {
+        _viewUpdater.renderFallbackDateInput(id, labelText);
+        // define variables
+        const fallBackDateInput = document.getElementById(id);
+        const yearSelect = document.getElementById(id + '__year');
+        const monthSelect = document.getElementById(id + '__month');
+        const daySelect = document.getElementById(id + '__day');
+        let previousDay = 1;
+
+        // populate the days and years dynamically
+        _viewUpdater.populateYears(id);
+        populateDays();
+
+        yearSelect.addEventListener('change', populateDays);
+        monthSelect.addEventListener('change', populateDays);
+        daySelect.addEventListener('change', () => {
+            previousDay = Number.parseInt(daySelect.value, 10);
+        });
+
+        function getValue() {
+            console.log(
+                `${yearSelect.value}-${monthSelect.value}-${daySelect.value}`
+            );
+            return `${yearSelect.value}-${monthSelect.value}-${daySelect.value}`;
+        }
+
+        function setValue(value) {
+            const [year, month, day] = value.split('-');
+            yearSelect.value = year;
+            monthSelect.value = month;
+            populateDays();
+            daySelect.value = day;
+        }
+
+        function addEventListener(event, callback) {
+            fallBackDateInput.addEventListener(event, callback, true);
+        }
+
+        function populateDays() {
+            _viewUpdater.populateDays(id, previousDay);
+        }
+
+        return {
+            get value() {
+                return getValue();
+            },
+            set value(value) {
+                setValue(value);
+            },
+            addEventListener,
+        };
+    }
+
+    return {
+        set viewUpdater(viewUpdater) {
+            _viewUpdater = viewUpdater;
+        },
+        createDateInput,
+    };
+})();
+
+export { dateInputFactory };

--- a/src/client/js/viewUpdater.js
+++ b/src/client/js/viewUpdater.js
@@ -4,6 +4,160 @@ const viewUpdater = (function () {
     let _applicationState;
     const cityInputElement = document.getElementById('city');
 
+    function renderNativeDateInput(id, labelText) {
+        const container = document.getElementById(id + '__container');
+        const fragment = document.createDocumentFragment();
+        const label = document.createElement('LABEL');
+        label.setAttribute('for', id);
+        label.textContent = labelText;
+        fragment.appendChild(label);
+        const input = document.createElement('INPUT');
+        input.type = 'date';
+        input.id = id;
+        input.name = id;
+        fragment.appendChild(input);
+        container.appendChild(fragment);
+    }
+
+    // This fallback date input is based on
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#Handling_browser_support
+    function renderFallbackDateInput(id, labelText) {
+        const container = document.getElementById(id + '__container');
+        const fragment = document.createDocumentFragment();
+        const label = document.createElement('P');
+        label.textContent = labelText;
+        fragment.appendChild(label);
+        const fallBackDateInput = document.createElement('DIV');
+        fallBackDateInput.id = id;
+        fallBackDateInput.innerHTML = `
+          <span>
+            <label for="${id}__day">Day:</label>
+            <select id="${id}__day" name="${id}__day">
+            </select>
+          </span>
+          <span>
+            <label for="${id}__month">Month:</label>
+            <select id="${id}__month" name="${id}__month">
+              <option value="01" selected>January</option>
+              <option value="02">February</option>
+              <option value="03">March</option>
+              <option value="04">April</option>
+              <option value="05">May</option>
+              <option value="06">June</option>
+              <option value="07">July</option>
+              <option value="08">August</option>
+              <option value="09">September</option>
+              <option value="10">October</option>
+              <option value="11">November</option>
+              <option value="12">December</option>
+            </select>
+          </span>
+          <span>
+            <label for="${id}__year">Year:</label>
+            <select id="${id}__year" name="${id}__year">
+            </select>
+          </span>`;
+
+        fragment.appendChild(fallBackDateInput);
+        container.appendChild(fragment);
+    }
+
+    function populateYears(id) {
+        const yearSelect = document.getElementById(id + '__year');
+        const date = new Date();
+        const year = date.getFullYear();
+        const fragment = document.createDocumentFragment();
+
+        // Make this year, and the 4 years after it available in the year <select>
+        for (let offset = 0; offset < 5; offset++) {
+            const option = document.createElement('OPTION');
+            option.textContent = year + offset;
+            option.value = year + offset;
+            fragment.appendChild(option);
+        }
+
+        yearSelect.appendChild(fragment);
+    }
+
+    function populateDays(id, previousDay) {
+        const year = document.getElementById(id + '__year').value;
+        const month = document.getElementById(id + '__month').value;
+        const daySelect = document.getElementById(id + '__day');
+        clearDayList(daySelect);
+
+        const daysInMonth = computeDaysInMonth(month, year);
+
+        renderDayList(daySelect, daysInMonth);
+
+        restorePreviousDay(daySelect, previousDay);
+    }
+
+    function clearDayList(daySelect) {
+        // delete the current set of <option> elements out of the
+        // day <select>, ready for the next set to be injected
+        while (daySelect.firstChild) {
+            daySelect.removeChild(daySelect.firstChild);
+        }
+    }
+
+    function computeDaysInMonth(month, year) {
+        let daysInMonth;
+        // 31 or 30 days?
+        if (
+            month === '04' ||
+            month === '06' ||
+            month === '09' ||
+            month === '11'
+        ) {
+            daysInMonth = 30;
+        } else if (month === '02') {
+            // If month is February, calculate whether it is a leap year or not
+            const isLeapYear = new Date(year, 1, 29).getMonth() == 1;
+            isLeapYear ? (daysInMonth = 29) : (daysInMonth = 28);
+        } else {
+            daysInMonth = 31;
+        }
+        return daysInMonth;
+    }
+
+    function renderDayList(daySelect, daysInMonth) {
+        for (let day = 1; day <= daysInMonth; day++) {
+            var option = document.createElement('option');
+            option.textContent = day;
+            option.value = addLeadingZero(day);
+            daySelect.appendChild(option);
+        }
+    }
+
+    function restorePreviousDay(daySelect, previousDay) {
+        // if previous day has already been set, set daySelect's value
+        // to that day, to avoid the day jumping back to 1 when you
+        // change the year
+        if (previousDay) {
+            daySelect.value = addLeadingZero(previousDay);
+
+            // If the previous day was set to a high number, say 31, and then
+            // you chose a month with less total days in it (e.g. February),
+            // this part of the code ensures that the highest day available
+            // is selected, rather than showing a blank daySelect
+            if (daySelect.value === '') {
+                daySelect.value = addLeadingZero(previousDay) - 1;
+            }
+
+            if (daySelect.value === '') {
+                daySelect.value = addLeadingZero(previousDay) - 2;
+            }
+
+            if (daySelect.value === '') {
+                daySelect.value = addLeadingZero(previousDay) - 3;
+            }
+        }
+    }
+
+    function addLeadingZero(day) {
+        return day < 10 ? '0' + day : day;
+    }
+
     function updateDateView() {
         document.getElementById('daysToTrip').textContent =
             _applicationState.daysToTrip +
@@ -11,9 +165,8 @@ const viewUpdater = (function () {
             (_applicationState.daysToTrip != 1 ? 's' : '');
         document.getElementById('duration').textContent =
             _applicationState.duration +
-            1 +
             ' day' +
-            (_applicationState.duration + 1 != 1 ? 's' : '');
+            (_applicationState.duration != 1 ? 's' : '');
     }
 
     function createNewCityList() {
@@ -189,6 +342,10 @@ const viewUpdater = (function () {
         set applicationState(applicationState) {
             _applicationState = applicationState;
         },
+        renderNativeDateInput,
+        renderFallbackDateInput,
+        populateYears,
+        populateDays,
         createNewCityList,
         setActiveCity,
         clearCityList,

--- a/src/client/views/index.html
+++ b/src/client/views/index.html
@@ -22,24 +22,9 @@
                         name="city"
                         placeholder="City"
                     />
-                    <input id="country" name="country" type="hidden" value="" />
-                    <input
-                        id="latitude"
-                        name="latitude"
-                        type="hidden"
-                        value=""
-                    />
-                    <input
-                        id="longitude"
-                        name="longitude"
-                        type="hidden"
-                        value=""
-                    />
                 </div>
-                <label for="startDate">Start Date</label>
-                <input type="date" id="startDate" name="startDate" value="" />
-                <label for="endDate">End Date</label>
-                <input type="date" id="endDate" name="endDate" value="" />
+                <div class="date" id="startDate__container"></div>
+                <div class="date" id="endDate__container"></div>
                 <input type="submit" value="Submit" id="submit" />
             </form>
             <div>Your trip is in <span id="daysToTrip">0 days</span></div>


### PR DESCRIPTION
Some modern browsers, notably Safari for desktop, still don't support
the date input element. A fallback date picker using select elements is
now provided.

- Create dateInputFactory to create the appropriate kind of input element
- Set dateInputFactory as an injected dependency in dateController.js
- Create methods to render the date inputs in viewUpdater.js
- Remove hard-coded date input elements and labels from index.html
- Set up the dateInputFactory and dateController in index.js

Solves #13